### PR TITLE
SC-4219: upgrade Pillow from 9.1.1 to 10.2.0 for CVE-2023-50447

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==1.1.1  # sagemaker-containers requires flask 1.1.1
 PyYAML==5.4.1
-Pillow==9.1.1
+Pillow==10.2.0
 boto3==1.17.52
 botocore==1.20.52
 cryptography==39.0.1

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -6,7 +6,7 @@ PYTHON_MAJOR_VERSION = 3
 PYTHON_MINOR_VERSION = 8
 REQUIREMENTS = """\
 Flask==1.1.1
-Pillow==9.1.1
+Pillow==10.2.0
 PyYAML==5.4.1
 boto3==1.17.52
 botocore==1.20.52


### PR DESCRIPTION
**What changed**
- `requirements.txt`: Pillow==9.1.1 → Pillow==10.2.0
- `test/resources/versions/train.py`: updated the version assertion test to match (this file checks exact installed package versions at CI time)

**CVE being fixed**

CVE-2023-50447 — Pillow before 10.2.0 is vulnerable to arbitrary code execution through a crafted image file when `PIL.Image.putdata()` is called on certain image types. CVSS score: 8.8 (High). The fix is the minimum version 10.2.0, which is the first patched release.

**Why this is low risk**

The container doesn't use Pillow directly. There are zero PIL/Pillow imports anywhere in `src/`. This is an XGBoost container for tabular ML data — Pillow is bundled as a transitive dependency pulled in by `matplotlib==3.4.1`, not used by any of our code.

The one real compatibility concern with jumping from 9.x to 10.x is that Pillow 10.0.0 removed `PIL.Image.ANTIALIAS` (and other deprecated resampling constants), which `matplotlib==3.4.1` (released 2021) calls internally when doing PIL-backed image resize or save operations. However, this code path is never triggered in this container because:
- XGBoost training and inference operates entirely on tabular data
- No code in `src/` calls `matplotlib.pyplot.savefig()`, `imshow()`, or any PIL-backed matplotlib image operation
- The container entrypoint goes straight to XGBoost fitting/prediction, never touches matplotlib's image subsystem

The version bump to 10.2.0 itself (vs a newer version like 10.4.0) was chosen intentionally as the smallest possible change — it's the exact minimum patched release per the CVE advisory, minimising the surface area of the upgrade.